### PR TITLE
Add Slack Explainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-No one is perfect. It's possible that some of these tips are outdated or not as optimal as they could be. To contribute to this repo, fork it, make changes, and open a pull request.
+No one is perfect. It's possible that some of these tips are outdated or not as optimal as they could be. To contribute to this repo, fork it, make changes, and open a pull request. If you see something you don't know how to fix, you can open an issue.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbt-tips
 
-Collection of dbt Tips and Tricks
+Collection of dbt tips and tricks. Includes links to the dbt slack community which you can [join here](https://www.getdbt.com/community/join-the-community). See something that needs to be changed? See [contributing guidelines](CONTRIBUTING.md).
 
 ## Skip to a Section
 


### PR DESCRIPTION
Closes #2 

I added an explanation to the top of the document that some links are to the dbt slack. If you haven't joined, it's a great place to learn about dbt features and get help with advanced use.